### PR TITLE
Basic support for session logout.

### DIFF
--- a/src/OpenID/Connect/Discovery.hs
+++ b/src/OpenID/Connect/Discovery.hs
@@ -209,6 +209,12 @@ data Discovery = Discovery
     -- registering the Client to read about OpenID Provider's terms of
     -- service. The registration process SHOULD display this URL to
     -- the person registering the Client if it is given.
+
+  , endSessionEndpoint :: Maybe URI
+    -- ^ URL at the OP to which an RP can perform a redirect to
+    -- request that the End-User be logged out at the OP. This URL MUST
+    -- use the https scheme and MAY contain port, path, and query
+    -- parameter components.
   }
   deriving stock (Generic, Show)
   deriving (ToJSON, FromJSON) via GenericJSON Discovery


### PR DESCRIPTION
This is basic support for the end session url. It is recommended to send the `idToken` with the endSessionUrl - which is just `encodeCompact` on the `SignedJWT`. I was thinking about creating a function that would generate the redirect uri, but I just wonder if it is really needed. 

https://openid.net/specs/openid-connect-rpinitiated-1_0.html