### PR TITLE
Use best available JWS alg for identity token fetch

### DIFF
--- a/openid-connect.cabal
+++ b/openid-connect.cabal
@@ -85,10 +85,10 @@ common dependencies
     , case-insensitive      ^>=1.2
     , containers            ^>=0.6
     , cookie                ^>=0.4
-    , cryptonite            >=0.25  && <1.0
+    , crypton               >=0.25  && <1.0
     , http-client           >=0.6   && <0.8
     , http-types            ^>=0.12
-    , jose                  >=0.10  && <0.11
+    , jose                  >=0.10  && <0.12
     , lens                  >=4.0   && <5.3
     , memory                >=0.14  && <1.0
     , mtl                   >=2.2   && <2.4

--- a/src/OpenID/Connect/Discovery.hs
+++ b/src/OpenID/Connect/Discovery.hs
@@ -22,6 +22,7 @@ module OpenID.Connect.Discovery
 
 --------------------------------------------------------------------------------
 -- Imports:
+import Crypto.JOSE.JWA.JWS
 import Data.List.NonEmpty (NonEmpty)
 import Data.Text (Text)
 import GHC.Generics (Generic)
@@ -91,7 +92,7 @@ data Discovery = Discovery
     -- ^ JSON array containing a list of the Subject Identifier types
     -- that this OP supports.
 
-  , idTokenSigningAlgValuesSupported :: NonEmpty Text
+  , idTokenSigningAlgValuesSupported :: NonEmpty Alg
     -- ^ JSON array containing a list of the JWS signing algorithms
     -- (alg values) supported by the OP for the ID Token to encode the
     -- Claims in a JWT.
@@ -106,7 +107,7 @@ data Discovery = Discovery
     -- (enc values) supported by the OP for the ID Token to encode the
     -- Claims in a JWT.
 
-  , userinfoSigningAlgValuesSupported :: Maybe (NonEmpty Text)
+  , userinfoSigningAlgValuesSupported :: Maybe (NonEmpty Alg)
     -- ^ JSON array containing a list of the JWS signing algorithms
     -- (alg values).
 
@@ -118,7 +119,7 @@ data Discovery = Discovery
     -- ^ JSON array containing a list of the JWE encryption algorithms
     -- (enc values).
 
-  , requestObjectSigningAlgValuesSupported :: Maybe (NonEmpty Text)
+  , requestObjectSigningAlgValuesSupported :: Maybe (NonEmpty Alg)
     -- ^ JSON array containing a list of the JWS signing algorithms
     -- (alg values) supported by the OP for Request Objects, which are
     -- described in Section 6.1 of OpenID Connect Core 1.0.
@@ -139,7 +140,7 @@ data Discovery = Discovery
     -- ^ JSON array containing a list of Client Authentication methods
     -- supported by this Token Endpoint.
 
-  , tokenEndpointAuthSigningAlgValuesSupported :: Maybe (NonEmpty Text)
+  , tokenEndpointAuthSigningAlgValuesSupported :: Maybe (NonEmpty Alg)
     -- ^ JSON array containing a list of the JWS signing algorithms
     -- (alg values) supported by the Token Endpoint for the signature
     -- on the JWT used to authenticate the Client at the Token


### PR DESCRIPTION
Right now, openid-connect is not using the `id_token_signing_alg_values_supported` data from the discovery document and only relies on JOSE's `bestJWSAlg` to select a signing algorithm to use. There's no guarantee that the recipient will recognize the signed token if it's using something out of the discovery document's advertised values.

This branch uses `negotiateJWSAlg` and the `alg_values_supported` list from the discovery document. This is a feature that's not yet in a released version of JOSE so the function may yet be subject to change. See https://github.com/frasertweedale/hs-jose/issues/118