### PR TITLE
Add Credentials to decodeIdentityToken for future JWE support

### DIFF
--- a/src/OpenID/Connect/Authentication.hs
+++ b/src/OpenID/Connect/Authentication.hs
@@ -22,16 +22,19 @@ module OpenID.Connect.Authentication
   , ClientID
   , ClientRedirectURI
   , AuthenticationRequest(..)
+  , clientSecretAsJWK
   ) where
 
 --------------------------------------------------------------------------------
 -- Imports:
 import Control.Applicative ((<|>))
 import Crypto.JOSE.JWK (JWK)
+import qualified Crypto.JOSE.JWK as JWK
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Types as Aeson
 import Data.ByteString (ByteString)
 import Data.Text (Text)
+import qualified Data.Text.Encoding as Text
 import GHC.Generics (Generic)
 import Network.HTTP.Types (QueryItem)
 import qualified Network.URI as Network
@@ -70,6 +73,16 @@ data ClientSecret
 --
 -- @since 0.1.0.0
 type ClientID = Text
+
+--------------------------------------------------------------------------------
+-- | Get credentials as a JWK, if applicable
+clientSecretAsJWK :: ClientSecret -> Maybe JWK
+clientSecretAsJWK (AssertionPrivateKey jwk) =
+  Just jwk
+-- Use the @client_secret@ as a /key/ to sign a JWT.
+clientSecretAsJWK (AssignedAssertionText keyBytes) =
+  Just $ JWK.fromOctets $ Text.encodeUtf8 keyBytes
+clientSecretAsJWK _ = Nothing
 
 --------------------------------------------------------------------------------
 -- | The client (relying party) redirection URL previously registered

--- a/src/OpenID/Connect/Client/Flow/AuthorizationCode.hs
+++ b/src/OpenID/Connect/Client/Flow/AuthorizationCode.hs
@@ -427,7 +427,7 @@ exchangeCodeForIdentityToken https now disco creds user = do
     processResponse res =
       parseResponse res
       & bimap InvalidProviderTokenResponseError fst
-      >>= (decodeIdentityToken >>> first TokenDecodingError)
+      >>= (decodeIdentityToken creds >>> first TokenDecodingError)
 
     authMethods :: [ClientAuthentication]
     authMethods = maybe [ClientSecretPost] NonEmpty.toList

--- a/src/OpenID/Connect/Client/TokenResponse.hs
+++ b/src/OpenID/Connect/Client/TokenResponse.hs
@@ -38,7 +38,7 @@ import Data.Maybe (isJust)
 import Data.Text (Text)
 import qualified Data.Text.Encoding as Text
 import Data.Time.Clock (UTCTime)
-import OpenID.Connect.Authentication (ClientID)
+import OpenID.Connect.Authentication
 import OpenID.Connect.Client.Provider
 import OpenID.Connect.TokenResponse
 
@@ -51,13 +51,23 @@ import qualified Data.HashMap.Strict as Map
 --------------------------------------------------------------------------------
 -- | Decode the compacted identity token into a 'SignedJWT'.
 decodeIdentityToken
-  :: TokenResponse Text
+  :: Credentials        -- ^ Decoding JWE requires decrypting as well
+  -> TokenResponse Text
   -> Either JOSE.Error (TokenResponse SignedJWT)
-decodeIdentityToken token
-  = JOSE.decodeCompact (LChar8.fromStrict (Text.encodeUtf8 (idToken token)))
-  & runExceptT
-  & runIdentity
-  & fmap (<$ token)
+decodeIdentityToken creds token = fmap (<$ token) $ runIdentity $ runExceptT $ do
+  -- First attempt it as a JWS
+  case JOSE.decodeCompact token' of
+    Right x -> pure x
+    -- Looks like a JWE
+    Left (JOSE.CompactDecodeError (JOSE.CompactInvalidNumberOfParts
+                                   (JOSE.InvalidNumberOfParts 3 5))) -> do
+      _ <- maybe (throwError JOSE.NoUsableKeys) pure $
+        clientSecretAsJWK $ clientSecret creds
+      -- Crypto.JOSE has no JWE support yet
+      throwError JOSE.AlgorithmNotImplemented
+    Left err -> throwError err
+  where
+    token' = LChar8.fromStrict (Text.encodeUtf8 (idToken token))
 
 --------------------------------------------------------------------------------
 -- | Identity token verification and claim validation.


### PR DESCRIPTION
https://github.com/frasertweedale/hs-jose still has no JWE support but this is for some preparatory work related to it. With this the only changes needed when it arrives should be localized to `OpenID.Connect.Client.TokenResponse` module only.

See https://github.com/pjones/openid-connect/issues/21